### PR TITLE
Fix to get console worked

### DIFF
--- a/src/app/main.js
+++ b/src/app/main.js
@@ -948,7 +948,7 @@ export default function App() {
 
     session.addCommandToList(command);
     session.setCommandCounter(session.getCommandList().length);
-    args = /^([a-zA-Z]+)(?:\s+([^\s].*)|)$/.exec(command);
+    var args = /^([a-zA-Z]+)(?:\s+([^\s].*)|)$/.exec(command);
 
     if (!args) {
       logger.error("Invalid command.");


### PR DESCRIPTION
Bug: When inputing commands on the console window, `Uncaught ReferenceError: args is not defined` occurs.

IoT.jsCode-DCO-1.0-Signed-off-by: Daeyeon Jeong daeyeon.jeong@samsung.com