### PR TITLE
Fix source sync behaviors

### DIFF
--- a/src/app/main.js
+++ b/src/app/main.js
@@ -851,6 +851,9 @@ export default function App() {
        * Sync source from jerry button.
        */
       $('#jerry-sync-source-button').on('click', () => {
+        if (surface.buttonIsDisabled('#jerry-sync-source-button')) {
+          return;
+        }
         session.syncSourceFromJerry();
         surface.toggleButton(false, 'jerry-sync-source-button');
       });

--- a/src/app/style/bright/panels.scss
+++ b/src/app/style/bright/panels.scss
@@ -245,6 +245,10 @@
     width: 100%;
   }
 
+  #jerry-sync-source-button:not(.disabled) {
+    border-color: $d-red-color;
+  }
+
   .logger-panel {
     position: relative;
     width: 100%;

--- a/src/app/style/dark/panels.scss
+++ b/src/app/style/dark/panels.scss
@@ -119,6 +119,10 @@
 
   }
 
+  #jerry-sync-source-button:not(.disabled) {
+    border-color: $d-red-color;
+  }
+
   .logger-panel {
     .data {
       .data-timestamp {

--- a/src/app/view/workspace/console.ejs
+++ b/src/app/view/workspace/console.ejs
@@ -5,7 +5,7 @@
       <div class="panel-heading">
         <span>Console</span>
         <div class="panel-heading-buttons">
-          <div class="btn btn-default btn-xs disabled" id="jerry-sync-source-button" title="Snyc source(s) from JerryScript.">Sync source</div>
+          <div class="btn btn-default btn-xs disabled" id="jerry-sync-source-button" title="Sync source(s) from JerryScript.">Sync source</div>
         </div>
       </div>
       <div class="panel-body console">


### PR DESCRIPTION
This patch mainly prevent that the sync button is clicked in disabled.
The style in the enabled state is a bit changed more noticeable.

IoT.jsCode-DCO-1.0-Signed-off-by: Daeyeon Jeong daeyeon.jeong@samsung.com