### PR TITLE
Fix backtrace

### DIFF
--- a/src/app/modules/client/connection.js
+++ b/src/app/modules/client/connection.js
@@ -28,6 +28,7 @@ export default class Connection {
    * @param {object} address Connection host address and host port.
    */
   constructor(debuggerObject, address) {
+    this._backtrace = [];
     this._eventEmitter = new EventEmitter();
 
     this._debuggerObj = debuggerObject;
@@ -173,11 +174,10 @@ export default class Connection {
 
         case PROTOCOL.SERVER.JERRY_DEBUGGER_BACKTRACE:
         case PROTOCOL.SERVER.JERRY_DEBUGGER_BACKTRACE_END: {
-          let backtrace = [];
 
           for (let i = 1; i < message.byteLength; i += this._debuggerObj.cPointerSize + 4) {
             const breakpointData = this._debuggerObj.decodeMessage('CI', message, i);
-            backtrace.push({
+            this._backtrace.push({
               frame: this._debuggerObj.backtraceFrame,
               data: this._debuggerObj.getBreakpoint(breakpointData).breakpoint,
             });
@@ -186,9 +186,9 @@ export default class Connection {
 
           if (message[0] === PROTOCOL.SERVER.JERRY_DEBUGGER_BACKTRACE_END) {
             this._debuggerObj.backtraceFrame = 0;
-            this._eventEmitter.emit('backtrace', [event, backtrace]);
+            this._eventEmitter.emit('backtrace', [event, this._backtrace]);
+            this._backtrace = [];
           }
-
           return;
         }
 

--- a/src/app/modules/client/debugger.js
+++ b/src/app/modules/client/debugger.js
@@ -729,6 +729,7 @@ export default class DebuggerClient {
   sendGetBacktrace(userDepth) {
     if (this._mode.current === ENGINE_MODE.BREAKPOINT) {
       let max_depth = 0;
+      let min_depth = 0;
 
       if (userDepth !== 0) {
         if (/[1-9][0-9]*/.test(userDepth)) {
@@ -736,8 +737,7 @@ export default class DebuggerClient {
         }
       }
 
-      this.encodeMessage('BI', [PROTOCOL.CLIENT.JERRY_DEBUGGER_GET_BACKTRACE, max_depth]);
-
+      this.encodeMessage('BII', [PROTOCOL.CLIENT.JERRY_DEBUGGER_GET_BACKTRACE, min_depth, max_depth]);
       return DEBUGGER_RETURN_TYPES.COMMON.SUCCESS;
     }
 


### PR DESCRIPTION
If you had a backtrace that had more than 20 frames it cleared the previous ones from the table.

IoT.jsCode-DCO-1.0-Signed-off-by: Daniella Barsony bella@inf.u-szeged.hu