### PR TITLE
Fix panel highlight in source sending panel

### DIFF
--- a/src/app/style/bright/panels.scss
+++ b/src/app/style/bright/panels.scss
@@ -196,11 +196,11 @@
           overflow-y: auto;
 
           .ui-selecting {
-            background-color: $b-yellow-color;
+            background-color: $b-yellow-color !important;
           }
 
           .ui-selected {
-            background-color: $b-orange-color;
+            background-color: $b-orange-color !important;
             color: #fff;
           }
 


### PR DESCRIPTION
Selecting a source in the source sending panel while Light theme was applied, you couldn't read the text that was on the button.

IoT.jsCode-DCO-1.0-Signed-off-by: Daniella Barsony bella@inf.u-szeged.hu