### PR TITLE
Add the start, end interval for backtrace

### DIFF
--- a/src/app/modules/client/connection.js
+++ b/src/app/modules/client/connection.js
@@ -28,6 +28,7 @@ export default class Connection {
    * @param {object} address Connection host address and host port.
    */
   constructor(debuggerObject, address) {
+    this._total_frame_counter = null;
     this._backtrace = [];
     this._eventEmitter = new EventEmitter();
 
@@ -172,9 +173,13 @@ export default class Connection {
           return;
         }
 
+        case PROTOCOL.SERVER.JERRY_DEBUGGER_BACKTRACE_TOTAL: {
+          this._total_frame_counter = this._debuggerObj.decodeMessage('I', message, 1);
+          return;
+        }
+
         case PROTOCOL.SERVER.JERRY_DEBUGGER_BACKTRACE:
         case PROTOCOL.SERVER.JERRY_DEBUGGER_BACKTRACE_END: {
-
           for (let i = 1; i < message.byteLength; i += this._debuggerObj.cPointerSize + 4) {
             const breakpointData = this._debuggerObj.decodeMessage('CI', message, i);
             this._backtrace.push({
@@ -236,6 +241,9 @@ export default class Connection {
     };
   }
 
+  get total_frame_counter() {
+    return this._total_frame_counter;
+  }
   get exceptionData() {
     return this._exceptionData;
   }

--- a/src/app/modules/client/debugger.js
+++ b/src/app/modules/client/debugger.js
@@ -22,7 +22,7 @@ import { EventEmitter } from 'events';
 /**
  * Expected Debugger Protocol version.
  */
-export const JERRY_DEBUGGER_VERSION = 4;
+export const JERRY_DEBUGGER_VERSION = 5;
 
 /**
  * Packages sent between the server and the client.
@@ -48,13 +48,14 @@ export const PROTOCOL = {
     JERRY_DEBUGGER_EXCEPTION_HIT: 17,
     JERRY_DEBUGGER_EXCEPTION_STR: 18,
     JERRY_DEBUGGER_EXCEPTION_STR_END: 19,
-    JERRY_DEBUGGER_BACKTRACE: 20,
-    JERRY_DEBUGGER_BACKTRACE_END: 21,
-    JERRY_DEBUGGER_EVAL_RESULT: 22,
-    JERRY_DEBUGGER_EVAL_RESULT_END: 23,
-    JERRY_DEBUGGER_WAIT_FOR_SOURCE: 24,
-    JERRY_DEBUGGER_OUTPUT_RESULT: 25,
-    JERRY_DEBUGGER_OUTPUT_RESULT_END: 26,
+    JERRY_DEBUGGER_BACKTRACE_TOTAL: 20,
+    JERRY_DEBUGGER_BACKTRACE: 21,
+    JERRY_DEBUGGER_BACKTRACE_END: 22,
+    JERRY_DEBUGGER_EVAL_RESULT: 23,
+    JERRY_DEBUGGER_EVAL_RESULT_END: 24,
+    JERRY_DEBUGGER_WAIT_FOR_SOURCE: 25,
+    JERRY_DEBUGGER_OUTPUT_RESULT: 26,
+    JERRY_DEBUGGER_OUTPUT_RESULT_END: 27,
 
     // Subtypes of eval.
     JERRY_DEBUGGER_EVAL_EVAL: '\u0000',
@@ -720,24 +721,23 @@ export default class DebuggerClient {
   }
 
   /**
-   * Gets the backtrace depth options from the settings page and send that to the debugger.
-   * This signal can be sended to the engine only in breakpoint mode.
+   * Gets the total backtrace count options from the settings page and send that to the debugger.
+   * This signal can be sent to the engine only in breakpoint mode.
    *
    * @return {DEBUGGER_RETURN_TYPES} COMMON.SUCCESS in case of successful signal send and
    *                                 COMMON.ALLOWED_IN_BREAKPOINT_MODE in case of invalid engine mode.
    */
-  sendGetBacktrace(userDepth) {
+  sendGetBacktrace(min_depth, max_depth, userTotal) {
     if (this._mode.current === ENGINE_MODE.BREAKPOINT) {
-      let max_depth = 0;
-      let min_depth = 0;
 
-      if (userDepth !== 0) {
-        if (/[1-9][0-9]*/.test(userDepth)) {
-          max_depth = parseInt(userDepth);
-        }
+      if (min_depth === undefined) min_depth = 0;
+      if (max_depth === undefined) max_depth = 0;
+      let get_total = 0;
+
+      if (userTotal !== undefined) {
+        get_total = 1;
       }
-
-      this.encodeMessage('BII', [PROTOCOL.CLIENT.JERRY_DEBUGGER_GET_BACKTRACE, min_depth, max_depth]);
+      this.encodeMessage('BIIB', [PROTOCOL.CLIENT.JERRY_DEBUGGER_GET_BACKTRACE, min_depth, max_depth, get_total]);
       return DEBUGGER_RETURN_TYPES.COMMON.SUCCESS;
     }
 

--- a/src/app/session.js
+++ b/src/app/session.js
@@ -967,6 +967,7 @@ export default class Session {
    */
   reset() {
     Util.clearElement($('#backtrace-table-body'));
+    $('#backtrace-scroll').scrollTop(0);
     this.unhighlightLine();
     this._glyph.removeAll();
     this._marker.remove();

--- a/src/app/settings.js
+++ b/src/app/settings.js
@@ -135,7 +135,7 @@ export default class Settings {
         }, false],
       },
       debugger: {
-        backtraceDepth: [CONTROL_TYPE.NUMBER, value => this.modify('debugger.backtraceDepth', value), 0],
+        backtraceRange: [CONTROL_TYPE.CHECKBOX, value => this.modify('debugger.backtraceRange', value), true],
         transpileToES5: [CONTROL_TYPE.CHECKBOX, value => this.modify('debugger.transpileToES5', value), false],
       },
       panels: {

--- a/src/app/surface.js
+++ b/src/app/surface.js
@@ -713,6 +713,7 @@ export default class Surface {
    */
   updateBacktracePanel(backtrace, settings, transpiler) {
     const $table = $('#backtrace-table-body');
+    let frame = $('#backtrace-min-depth').val() || 0;
 
     backtrace.forEach(trace => {
       const sourceName = trace.data.func.sourceName || trace.data;
@@ -724,14 +725,18 @@ export default class Surface {
 
       $table.append(
         '<tr>' +
-          `<td>${trace.frame}</td>` +
+          `<td>${frame}</td>` +
           `<td>${sourceName}</td>` +
           `<td>${line}</td>` +
           `<td>${this.generateFunctionLog(trace.data, settings, transpiler)}</td>` +
         '</tr>'
       );
+      frame++;
 
       Util.scrollDown($table);
+
+      $('#backtrace-min-depth').val('');
+      $('#backtrace-max-depth').val('');
     });
   }
 

--- a/src/app/view/sidenav.ejs
+++ b/src/app/view/sidenav.ejs
@@ -146,8 +146,9 @@
     <div class="control-block" id="debugger-control-block">
       <h4>Debugger</h4>
       <div class="control-item">
-        <label for="backtraceDepth">Backtrace depth</label>
-        <input type="number" name="backtraceDepth" id="backtraceDepth" class="form-control input-sm" title="Maximum depth of backtrace. 0 by default." min="0" value="0">
+        <input type="checkbox" id="backtraceRange">
+        <label for="backtraceRange">Total backtrace count</label>
+        <p>Enable this if you want to use [start, end] interval for backtrace.</p>
       </div>
       <div class="control-item">
         <input type="checkbox" id="transpileToES5">

--- a/src/app/view/workspace/backtrace.ejs
+++ b/src/app/view/workspace/backtrace.ejs
@@ -4,9 +4,14 @@
     <div class="panel panel-default">
       <div class="panel-heading">
         <span>Backtrace</span>
+        <div class="panel-heading-buttons">
+            <input type="text" class="form-control input-sm backtrace-text hidden-panel"  style="height: 20px !important; width: 70px !important" id="backtrace-min-depth" placeholder="Min depth">
+            <input type="text" class="form-control input-sm backtrace-text hidden-panel" style="height: 20px !important; width: 70px !important" id="backtrace-max-depth" placeholder="Max depth" >
+            <div class="btn btn-default btn-xs disabled" id="send-backtrace-button" title="Send backtrace request">Select</div>
+        </div>
       </div>
       <div class="panel-body backtrace">
-        <div class="wrapper perfect-scrollable">
+        <div class="wrapper perfect-scrollable" id="backtrace-scroll">
           <table class="table table-striped table-hover scroll-table" id="backtrace-table">
             <thead>
               <tr>


### PR DESCRIPTION
Enable this in the side navigation bar under `Settings`. If `Total backtrace count` is checked it brings up the input text boxes and enables the button to send.
Sending a backtrace request with no frames given will list all of them.

IoT.jsCode-DCO-1.0-Signed-off-by: Daniella Barsony bella@inf.u-szeged.hu